### PR TITLE
fix, Unsupported operation: Cannot remove from a fixed-length list

### DIFF
--- a/lib/desktop_multi_window.dart
+++ b/lib/desktop_multi_window.dart
@@ -85,12 +85,11 @@ class DesktopMultiWindow {
     try {
       final result = await miltiWindowChannel
           .invokeMethod<List<int>>('getAllSubWindowIds');
-      var ids = result ?? [];
-      // remove 0
-      ids.removeWhere((e) => e == 0);
+      var ids = result?.where((id) => id != 0)?.toList() ?? [];
       assert(ids.every((id) => id > 0), 'id must be greater than 0');
       return ids;
     } catch (e) {
+      print('Unreachable, plugin exception, func getAllSubWindowIds(), $e');
       return [];
     }
   }


### PR DESCRIPTION
The exception of `ids.removeWhere((e) => e == 0);` in `getAllSubWindowIds()` causes rustdesk.exe hang up on exit if there're two sub-windows.


https://github.com/rustdesk-org/rustdesk_desktop_multi_window/assets/136106582/6169f167-c387-4e1e-81de-27ebc1f672b6


<img width="518" alt="1695043605268" src="https://github.com/rustdesk-org/rustdesk_desktop_multi_window/assets/136106582/22f0afdd-3449-4abf-8981-b8abc223c5e0">
