### PR TITLE
do not restore window on first movement

### DIFF
--- a/windows/base_flutter_window.cc
+++ b/windows/base_flutter_window.cc
@@ -330,7 +330,16 @@ void BaseFlutterWindow::SetBounds(double_t x, double_t y, double_t width, double
   if (!handle) {
     return;
   }
-  ShowWindow(handle, SW_RESTORE);
+  // A simple workaround for the first problem https://github.com/rustdesk/rustdesk/issues/5791
+  // If is the first call to move window, we do not call ShowWindow(handle, SW_RESTORE), to avoid the blank window.
+  if (is_first_move_) {
+    is_first_move_ = false;
+  } else {
+    // We do need the following call or `SetWindowPlacement` to set the window `showCmd` value.
+    // MoveWindow will not change the `showCmd` value of `GetWindowPlacement`.
+    // So the state of the window will be wrong after the window is maximized or minimized and then moved.
+    ShowWindow(handle, SW_RESTORE);
+  }
   MoveWindow(handle, int32_t(x), int32_t(y),
              static_cast<int>(width),
              static_cast<int>(height),

--- a/windows/base_flutter_window.h
+++ b/windows/base_flutter_window.h
@@ -81,6 +81,7 @@ private:
 	bool is_frameless_ = false;
   bool is_prevent_close_ = false;
 
+  bool is_first_move_ = true;
 };
 
 #endif //MULTI_WINDOW_WINDOWS_BASE_FLUTTER_WINDOW_H_


### PR DESCRIPTION
Fix the first problem of https://github.com/rustdesk/rustdesk/issues/5791 .

`MoveWindow` will not change the `showCmd` value of `GetWindowPlacement`.
So the `showCmd` is incorrect aftering moving.

This is a simple workaround. I didn't find a good way to set `showCmd`.

The issue


https://github.com/rustdesk-org/rustdesk_desktop_multi_window/assets/13586388/48d1d4c9-8aac-4482-9cca-34cb8a6141c9



Fixed


https://github.com/rustdesk-org/rustdesk_desktop_multi_window/assets/13586388/02bca13a-6194-41f4-931b-ef38857d3bb3




