### PR TITLE
Refact/subwindow background black

### DIFF
--- a/windows/base_flutter_window.cc
+++ b/windows/base_flutter_window.cc
@@ -345,7 +345,9 @@ void BaseFlutterWindow::SetBounds(double_t x, double_t y, double_t width, double
     // We do need the following call or `SetWindowPlacement` to set the window `showCmd` value.
     // MoveWindow will not change the `showCmd` value of `GetWindowPlacement`.
     // So the state of the window will be wrong after the window is maximized or minimized and then moved.
-    ShowWindow(handle, SW_RESTORE);
+    if (IsWindowVisible(handle) == TRUE) {
+      ShowWindow(handle, SW_RESTORE);
+    }
   }
   MoveWindow(handle, int32_t(x), int32_t(y),
              static_cast<int>(width),

--- a/windows/base_flutter_window.cc
+++ b/windows/base_flutter_window.cc
@@ -345,7 +345,11 @@ void BaseFlutterWindow::SetBounds(double_t x, double_t y, double_t width, double
     // We do need the following call or `SetWindowPlacement` to set the window `showCmd` value.
     // MoveWindow will not change the `showCmd` value of `GetWindowPlacement`.
     // So the state of the window will be wrong after the window is maximized or minimized and then moved.
-    if (IsWindowVisible(handle) == TRUE) {
+    WINDOWPLACEMENT windowPlacement;
+    GetWindowPlacement(handle, &windowPlacement);
+    if (windowPlacement.showCmd == SW_SHOWMAXIMIZED || windowPlacement.showCmd == SW_SHOWMINIMIZED) {
+      // Both `PostMessage(handle, WM_SYSCOMMAND, SC_RESTORE, 0);` and `ShowWindow(handle, SW_RESTORE);`
+      // have a side effect that the window will be show if it is hidden.
       ShowWindow(handle, SW_RESTORE);
     }
   }

--- a/windows/flutter_window.cc
+++ b/windows/flutter_window.cc
@@ -77,6 +77,7 @@ void RegisterWindowClass(WNDPROC wnd_proc) {
     window_class.hbrBackground = (HBRUSH) (COLOR_WINDOW + 1);
     window_class.lpszMenuName = nullptr;
     window_class.lpfnWndProc = wnd_proc;
+    window_class.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
     RegisterClass(&window_class);
   }
   class_registered_++;


### PR DESCRIPTION
1. Detect if is maximized or minimized, then restore window. Because `ShowWindow(handle, SW_RESTORE);` has a side effect that the window will show if it is hidden.
2. Set the background color to black. Windows only.

### Before



https://github.com/rustdesk-org/rustdesk_desktop_multi_window/assets/13586388/f645d4f6-673c-4ccb-970f-4801d5245bf0


### After


https://github.com/rustdesk-org/rustdesk_desktop_multi_window/assets/13586388/ad27e147-81f2-448b-ad2b-8f937b543ba2

