### PR TITLE
fix: windows, adjustNCCALCSIZE with monitor coords

### DIFF
--- a/windows/flutter_window.cc
+++ b/windows/flutter_window.cc
@@ -215,7 +215,7 @@ LRESULT FlutterWindow::MessageHandler(HWND hwnd, UINT message, WPARAM wparam, LP
         if (wparam && IsFrameless()) {
             // Add borders when maximized so app doesn't get cut off.
             if (IsMaximized()) {
-                adjustNCCALCSIZE(reinterpret_cast<NCCALCSIZE_PARAMS*>(lparam));
+                adjustNCCALCSIZE(hwnd, reinterpret_cast<NCCALCSIZE_PARAMS*>(lparam));
             }
             // This cuts the app at the bottom by one pixel but that's necessary to
             // prevent jitter when resizing the app
@@ -226,7 +226,7 @@ LRESULT FlutterWindow::MessageHandler(HWND hwnd, UINT message, WPARAM wparam, LP
         if (wparam && this->title_bar_style_ == "hidden") {
             // Add 8 pixel to the top border when maximized so the app isn't cut off
             if (this->IsMaximized()) {
-                adjustNCCALCSIZE(reinterpret_cast<NCCALCSIZE_PARAMS*>(lparam));
+                adjustNCCALCSIZE(hwnd, reinterpret_cast<NCCALCSIZE_PARAMS*>(lparam));
             }
             else {
                 NCCALCSIZE_PARAMS* sz = reinterpret_cast<NCCALCSIZE_PARAMS*>(lparam);

--- a/windows/flutter_window.h
+++ b/windows/flutter_window.h
@@ -75,9 +75,30 @@ class FlutterWindow : public BaseFlutterWindow {
 
   void tryInvokeChannelOnDestroy();
 
-  void adjustNCCALCSIZE(NCCALCSIZE_PARAMS* sz) {
-    LONG l = sz->rgrc[0].left;
-    LONG t = sz->rgrc[0].top;
+  void adjustNCCALCSIZE(HWND hwnd, NCCALCSIZE_PARAMS *sz) {
+    LONG l = 8;
+    LONG t = 8;
+
+    HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    if (monitor != NULL)
+    {
+      MONITORINFO monitorInfo;
+      monitorInfo.cbSize = sizeof(MONITORINFO);
+      if (TRUE == GetMonitorInfo(monitor, &monitorInfo))
+      {
+        l = sz->rgrc[0].left - monitorInfo.rcWork.left;
+        t = sz->rgrc[0].top - monitorInfo.rcWork.top;
+      }
+      else
+      {
+        // GetMonitorInfo failed, use (8, 8) as default value
+      }
+    }
+    else
+    {
+      // unreachable code
+    }
+
     sz->rgrc[0].left -= l;
     sz->rgrc[0].top -= t;
     sz->rgrc[0].right += l;


### PR DESCRIPTION
This commit may also fix https://github.com/rustdesk/rustdesk/issues/9033

### Display settings

![image](https://github.com/user-attachments/assets/8188c207-42b8-4f38-b583-ed5bd6badb33)


Monitor 1

![image](https://github.com/user-attachments/assets/02aa126f-e26a-4f7c-a586-677c6672222e)


### Bug


https://github.com/user-attachments/assets/38539689-f06f-4cb0-ba04-1f45f76969a7


### Fixed


https://github.com/user-attachments/assets/f8874f9f-fb01-49d6-b2c7-fea025eb584c

