### PR TITLE
fix: scale ratio on dpi change

### DIFF
--- a/windows/flutter_window.cc
+++ b/windows/flutter_window.cc
@@ -281,6 +281,13 @@ LRESULT FlutterWindow::MessageHandler(HWND hwnd, UINT message, WPARAM wparam, LP
       break;
     }
     case WM_DPICHANGED: {
+      auto newRectSize = reinterpret_cast<RECT *>(lparam);
+      LONG newWidth = newRectSize->right - newRectSize->left;
+      LONG newHeight = newRectSize->bottom - newRectSize->top;
+
+      SetWindowPos(hwnd, nullptr, newRectSize->left, newRectSize->top, newWidth,
+                   newHeight, SWP_NOZORDER | SWP_NOACTIVATE);
+
       ForceChildRefresh();
 
       return 0;


### PR DESCRIPTION
I'm sorry, in [PR](https://github.com/rustdesk-org/rustdesk_desktop_multi_window/pull/24/files) I deleted the necessary code to update the size of window when scale change.
> How to Reproduce: When the set window cannot be resized, it will break the layout when switching between monitors.
I have reverted it in this PR. Please review, Thanks!