### PR TITLE
feat: windows, set init background color

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -85,6 +85,9 @@ class _ExampleMainWindowState extends State<_ExampleMainWindow> {
                       'args3': true,
                       'bussiness': 'bussiness_test',
                     }));
+                    if (Platform.isWindows) {
+                      window.setInitBackgroundColor(Colors.green);
+                    }
                     window
                       ..setFrame(const Offset(0, 0) & const Size(1280, 720))
                       ..center()

--- a/lib/src/window_controller.dart
+++ b/lib/src/window_controller.dart
@@ -98,4 +98,10 @@ abstract class WindowController {
   ///
   /// This is only valid in x11/Linux.
   Future<int> getXID();
+
+  // https://github.com/rustdesk-org/rustdesk_desktop_multi_window/pull/26
+  /// Sets the background color before showing the window.
+  /// 
+  /// @platforms windows
+  Future<void> setInitBackgroundColor(Color color);
 }

--- a/lib/src/window_controller_impl.dart
+++ b/lib/src/window_controller_impl.dart
@@ -191,4 +191,16 @@ class WindowControllerMainImpl extends WindowController {
     return await _channel.invokeMethod<bool>('isFullScreen', arguments) ??
         false;
   }
+
+  @override
+  Future<void> setInitBackgroundColor(Color color) async {
+     final Map<String, dynamic> arguments = {
+      'windowId': _id,
+      'a': color.alpha,
+      'r': color.red,
+      'g': color.green,
+      'b': color.blue,
+    };
+    await _channel.invokeMethod('setInitBackgroundColor', arguments);
+  }
 }

--- a/windows/base_flutter_window.cc
+++ b/windows/base_flutter_window.cc
@@ -305,6 +305,16 @@ void BaseFlutterWindow::SetTitleBarStyle(const flutter::EncodableMap& args) {
     // std::cout << "set title bar styled" << std::endl;
 }
 
+void BaseFlutterWindow::SetInitBackgroundColor(const flutter::EncodableMap *args) {
+  int colorA = std::get<int>(args->at(flutter::EncodableValue("a")));
+  int colorR = std::get<int>(args->at(flutter::EncodableValue("r")));
+  int colorG = std::get<int>(args->at(flutter::EncodableValue("g")));
+  int colorB = std::get<int>(args->at(flutter::EncodableValue("b")));
+  bool isTransparent = colorA == 0 && colorR == 0 && colorG == 0 && colorB == 0;
+  erase_transparent_ = isTransparent;
+  erase_background_color_ = RGB(colorR, colorG, colorB);
+}
+
 void BaseFlutterWindow::SetAsFrameless() {
     is_frameless_ = true;
     HWND hWnd = GetWindowHandle();

--- a/windows/base_flutter_window.h
+++ b/windows/base_flutter_window.h
@@ -58,6 +58,8 @@ class BaseFlutterWindow {
 
   void ShowTitlebar(bool show);
 
+  void SetInitBackgroundColor(const flutter::EncodableMap *args);
+
   void StartResizing(const flutter::EncodableMap *param);
 
   bool IsPreventClose();
@@ -72,6 +74,14 @@ class BaseFlutterWindow {
 
   virtual HWND GetWindowHandle() = 0;
 
+  inline bool IsEraseTransparent() {
+    return erase_transparent_;
+  }
+
+  inline COLORREF GetEraseBackgroundColor() {
+    return erase_background_color_;
+  }
+
 private:
 	bool g_is_window_fullscreen = false;
 	std::string g_title_bar_style_before_fullscreen;
@@ -82,6 +92,9 @@ private:
 	LONG g_ex_style_before_fullscreen;
 	bool is_frameless_ = false;
   bool is_prevent_close_ = false;
+
+  COLORREF erase_background_color_ = RGB(255, 255, 255);
+  bool erase_transparent_ = false;
 
   bool is_first_move_ = true;
 };

--- a/windows/desktop_multi_window_plugin.cpp
+++ b/windows/desktop_multi_window_plugin.cpp
@@ -193,6 +193,11 @@ void DesktopMultiWindowPlugin::HandleMethodCall(
     auto res = MultiWindowManager::Instance()->IsPreventClose(window_id);
     result->Success(flutter::EncodableValue(res));
     return;
+  } else if (method_call.method_name() == "setInitBackgroundColor") {
+    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id = arguments->at(flutter::EncodableValue("windowId")).LongValue();
+    MultiWindowManager::Instance()->SetInitBackgroundColor(window_id, arguments);
+    return result->Success();
   }
   result->NotImplemented();
 }

--- a/windows/flutter_window.cc
+++ b/windows/flutter_window.cc
@@ -365,7 +365,16 @@ LRESULT FlutterWindow::MessageHandler(HWND hwnd, UINT message, WPARAM wparam, LP
         EmitEvent(eventName);
         break;
     }
-
+    case WM_ERASEBKGND: {
+        if(IsEraseTransparent()) break;
+        HDC hdc = (HDC) wparam;
+        HBRUSH brush = CreateSolidBrush(GetEraseBackgroundColor());
+        RECT rect;
+        GetClientRect(hwnd, &rect);
+        FillRect(hdc, &rect, brush);
+        DeleteObject(brush);
+        return 1; // Background has been erased
+    }
     default: break;
   }
 

--- a/windows/multi_window_manager.cc
+++ b/windows/multi_window_manager.cc
@@ -278,3 +278,10 @@ bool MultiWindowManager::IsFullscreen(int64_t id) {
   }
   return false;
 }
+
+void MultiWindowManager::SetInitBackgroundColor(int64_t id, const flutter::EncodableMap *args) {
+  auto window = windows_.find(id);
+  if (window != windows_.end()) {
+    return window->second->SetInitBackgroundColor(args);
+  }
+}

--- a/windows/multi_window_manager.h
+++ b/windows/multi_window_manager.h
@@ -45,6 +45,8 @@ class MultiWindowManager : public std::enable_shared_from_this<MultiWindowManage
 
   void ShowTitlebar(int64_t id, bool show);
 
+  void SetInitBackgroundColor(int64_t id, const flutter::EncodableMap *args);
+
   bool IsFullscreen(int64_t id);
 
   void SetFullscreen(int64_t id, bool fullscreen);


### PR DESCRIPTION
Add this feat for the fix https://github.com/rustdesk-org/rustdesk_desktop_multi_window/pull/26#issuecomment-2396694156


https://github.com/user-attachments/assets/bf42eb84-46c3-4b9d-9dee-18c59fa9aec5


from https://github.com/guide-inc-org/guide-flutter_desktop_multi_window/tree/b487a8bb4ac18783082a39e24e411dc295a4537d


`setBackgroundColor` seems not work on Windows, Linux and MacOS. So the function is not introduced. https://github.com/leanflutter/window_manager/blob/73c39f406c56de682b6c34d8cc744cecdcb471bb/lib/src/window_manager.dart#L319

