### PR TITLE
Fixed the crash issue when MainWindow releases channel

### DIFF
--- a/windows/multi_window_manager.cc
+++ b/windows/multi_window_manager.cc
@@ -20,7 +20,11 @@ class FlutterMainWindow : public BaseFlutterWindow {
 
   }
 
-  ~FlutterMainWindow() override = default;
+  ~FlutterMainWindow() override {
+    if (channel_) {
+      channel_.release();
+    }
+  };
 
   WindowChannel *GetWindowChannel() override {
     return channel_.get();


### PR DESCRIPTION
The release of the channel should be before the release of the flutter engine, just like the code in the child window: https://github.com/vitoway/rustdesk_desktop_multi_window/blob/4f562ab49d289cfa36bfda7cff12746ec0200033/windows/flutter_window.cc#L404 However, the main window will release the channel after the engine, and since the program is about to exit, there is no need to release the channel.